### PR TITLE
不具合修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,9 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   before_action :configure_permitted_parameters, if: :devise_controller?# ユーザー登録時に名前を登録できるように追記
+  add_flash_types :success, :danger
   allow_browser versions: :modern
+
 
   def configure_permitted_parameters # ユーザー登録時に名前を登録できるように定義
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :user_name ])

--- a/app/controllers/rackets_controller.rb
+++ b/app/controllers/rackets_controller.rb
@@ -10,9 +10,9 @@ class RacketsController < ApplicationController
   def create
     @racket = current_user.rackets.build(racket_params)
     if @racket.save
-      redirect_to rackets_path, success: t("defaults.flash_message.created", item: Racket.model_name.human)
+      redirect_to rackets_path, success: "ラケットの投稿に成功しました"
     else
-      flash.now[:danger] = t("defaults.flash_message.not_created", item: Racket.model_name.human)
+      flash.now[:danger] = "ラケットの投稿に失敗しました"
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/models/racket.rb
+++ b/app/models/racket.rb
@@ -3,12 +3,12 @@ class Racket < ApplicationRecord
 
   validates :product_name, presence: true, length: { maximum: 255 }
   validates :maker_name, presence: true, length: { maximum: 255 }
-  validates :face_size, inclusion: { in: 0...100 }
+  validates :face_size, inclusion: { in: 1..200 }, allow_blank: true
   validates :main_string, length: { maximum: 255 }
   validates :cross_string, length: { maximum: 255 }
-  validates :main_string_tension, length: { maximum: 255 }
-  validates :cross_string_tension, inclusion: { in: 0...100 }
-  validates :grip_size, inclusion: { in: 0...100 }
+  validates :main_string_tension, inclusion: { in: 1..100 }, allow_blank: true
+  validates :cross_string_tension, inclusion: { in: 1..100 }, allow_blank: true
+  validates :grip_size, inclusion: { in: 1..20 }, allow_blank: true
   validates :grip_tape, length: { maximum: 255 }
   validates :body, length: { maximum: 65_535 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,9 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :rackets, dependent: :destroy
+
+  # emailに関するバリデーション
+  validates :email, presence: true, uniqueness: true
+  # nameに関するバリデーション
+  validates :name, presence: true, uniqueness: true, length: { maximum: 50 }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
 
   <body>
     <%= render 'shared/header' %>
+    <%= render 'shared/flash_message' %> 
     <!-- <main class="container mx-auto mt-28 px-5 flex"> -->
       <%= yield %>
     </#main>

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -1,12 +1,20 @@
 <h1 class="text-4xl text-green-700 font-semibold underline">My Rake</h1>
-  <% if @rackets.present? %>
-    <% @rackets.each do |racket| %>
-      <%= racket.product_name %>
-			<%= racket.maker_name %>
-			<%= racket.created_at %>
-			<%= link_to '編集', '#' %>
-			<%= link_to '削除', '#' %>
+  <div>
+    <% if @rackets.present? %>
+      <% @rackets.each do |racket| %>
+      <div>
+        <%= racket.product_name %>
+      </div>
+        <%= racket.maker_name %>
+      <div>
+        <%= racket.created_at %>
+			</div>
+      <div>
+        <%= link_to '編集', '#' %>
+        <%= link_to '削除', '#' %>
+      </div>
+      <% end %>
+	  <% else %>
+      <p> 投稿がありません </p>
     <% end %>
-	<% else %>
-    <p> 投稿がありません </p>
-  <% end %>
+  </div>

--- a/app/views/rackets/new.html.erb
+++ b/app/views/rackets/new.html.erb
@@ -16,7 +16,7 @@
   <!-- 使用ラケットのフェイスサイズ -->
   <div>
     <%= f.label 'フェイスサイズ/inch' %>
-    <%= f.number_field :face_size  %>
+    <%= f.number_field :face_size, in: 1..200 %>
   </div>
 
 	<!-- 使用ラケットのガット（縦）の種類 -->
@@ -34,13 +34,13 @@
   <!-- ガットのテンション(縦) -->
   <div>
     <%= f.label '縦ガットのテンション' %>
-    <%= f.number_field :main_string_tension %>
+    <%= f.number_field :main_string_tension, in: 1..100 %>
   </div>
 
 	<!-- ガットのテンション(横) -->
   <div>
     <%= f.label '横ガットのテンション' %>
-    <%= f.number_field :cross_string_tension %>
+    <%= f.number_field :cross_string_tension, in: 1..100 %>
   </div>
 
 	<!-- 重りの使用箇所 -->
@@ -52,7 +52,7 @@
   <!-- グリップの太さ -->
   <div>
     <%= f.label 'グリップの太さ' %>
-    <%= f.number_field :grip_size %>
+    <%= f.number_field :grip_size, in: 1..20 %>
   </div>
 
   <!-- グリップテープ -->

--- a/app/views/rackets/new.html.erb
+++ b/app/views/rackets/new.html.erb
@@ -1,4 +1,4 @@
-<h1>投稿画面</h1>
+<h1 class="text-2xl font-semibold ">投稿画面</h1>
 <%= form_with model: @racket, class: "new_racket" do |f| %>
 
   <!-- 使用ラケット名 -->

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,6 @@
+<!-- フラッシュメッセージを表示 -->
+<% flash.each do | message_type ,message| %>
+  <div class= "<%= message_type %>" >
+    <%= message %>
+	</div>
+<% end %>


### PR DESCRIPTION
# 概要
4つの想定通りではない動きを修正しました。

## 空白でユーザーが登録できる
`app/models/user.rb`を編集
バリデーションを設定していなかったため修正

## 投稿画面にて負の数を選択できる
`app/views/rackets/new.html.erb`を編集
` <%= f.number_field :face_size, in: 1..200 %>`というように、
`in: 1..200`と範囲を設定。

## ラケット名とメーカー名を入力するだけで登録できるように変更
数字に範囲指定をしていることでバリデーションがかかってしまっている。
`app/models/racket.rb`を編集
`blank_allow :true`を設定
## フラッシュメッセージを表示させたい
- `app/controllers/application_controller.rb`の編集
  `add_flash_types :success, :danger`を設定
- `app/views/shared/_flash_message.html.erb`を作成
   フラッシュメッセージを表示する内容を記載
- `app/controllers/racket_controller.rb`の編集
   createアクションに投稿成功時と失敗時にフラッシュを表示するように編集