### PR TITLE
add:投稿したラケット情報を削除する機能を実装

### DIFF
--- a/app/controllers/rackets_controller.rb
+++ b/app/controllers/rackets_controller.rb
@@ -38,6 +38,14 @@ class RacketsController < ApplicationController
     @racket = current_user.rackets.find(params[:id])
   end
 
+  # ラケットの投稿削除アクション
+  def destroy
+    racket = current_user.rackets.find(params[:id])
+    racket.destroy!
+    redirect_to rackets_path, success: '投稿したマイラケ情報を削除しました。'
+  end
+
+
   private
   def racket_params
     params.require(:racket).permit(:product_name, :maker_name, :face_size, :main_string, :cross_string, :main_string_tension, :cross_string_tension,  :weight_position, :grip_size, :grip_tape, :body)

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -13,7 +13,7 @@
         <% if user_signed_in? %> <!-- ユーザーがログインしているか確認 -->
           <% if current_user.own?(racket) %> <!-- 投稿ユーザーがログインユーザー確認 -->
             <%= link_to '編集', edit_racket_path(racket) %>
-            <%= link_to '削除', '#' %>
+            <%= link_to '削除', racket_path(racket), data: { turbo_method: :delete, turbo_confirm: '削除しますか?'} %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/rackets/show.html.erb
+++ b/app/views/rackets/show.html.erb
@@ -75,7 +75,7 @@
     <%if user_signed_in? %>
       <% if current_user.own?(@racket) %>
         <%= link_to '編集', edit_racket_path(@racket) %>
-        <%= link_to '削除', '# ' %>
+        <%= link_to '削除', racket_path(@racket), data: { turbo_method: :delete, turbo_confirm: '削除しますか?'} %>
       <% end %>
 		<% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   get "static_pages/top"
   devise_for :users
   # get "rackets/index"
-  resources :rackets, only: %i[ index new  create show show edit update ]
+  resources :rackets
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
# 概要
削除機能の実装

## ルーティングの設定
`app/config/routes.rb`を編集
`resources :racket `に変更。

## コントローラーを定義
`app/controllers/rackets_controller.rb`の編集
destroyアクション追記

## 削除リンクを定義
` app/views/rackets/index.html.erb`を編集
`app/views/rackets/show.html.erb`を編集