### PR TITLE
update:ログイン後の画面遷移先をラケット投稿一覧ページに変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,12 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # ログイン後投稿一覧ページへ遷移するように指定
+  def after_sign_in_path_for(resource)
+    rackets_path
+  end
+
+  # ログアウト後のリダイレクト先を指定
   def after_sign_out_path_for(resource)
     new_user_session_path
   end


### PR DESCRIPTION
# 概要
ログイン後の画面遷移先がTOPページになっていたものをラケット投稿一覧ぺーじへ変更しました。