### PR TITLE
fix:renderエラーが発生したためconfig/storage.ymlを初期設定に戻す

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -10,10 +10,10 @@ local:
 # ラケット画像投稿機能はAmazon s3を利用/Railsチュートリアル参考
 amazon:
   service: S3
-  access_key_id:     <%= ENV['AWS_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
-  region:            <%= ENV['AWS_REGION'] %>
-  bucket:            <%= ENV['AWS_BUCKET'] %>
+  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+  region: us-east-1
+  bucket: your_own_bucket-<%= Rails.env %>
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
#　概要
renderエラーが発生したためconfig/storage.ymlを初期設定に戻す
Amazon S3での環境を構築及びRenderにて環境変数の入力後再度変更必要