### PR TITLE
add:画像表示サイズの変更及び画像投稿にバリデーションを設定

### DIFF
--- a/app/models/racket.rb
+++ b/app/models/racket.rb
@@ -4,6 +4,7 @@ class Racket < ApplicationRecord
   # ラケット投稿機能アソシエーション
   has_many_attached :images
 
+  # ラケット投稿機能のバリデーション
   validates :product_name, presence: true, length: { maximum: 255 }
   validates :maker_name, presence: true, length: { maximum: 255 }
   validates :face_size, inclusion: { in: 1..200 }, allow_blank: true
@@ -14,4 +15,9 @@ class Racket < ApplicationRecord
   validates :grip_size, inclusion: { in: 1..20 }, allow_blank: true
   validates :grip_tape, length: { maximum: 255 }
   validates :body, length: { maximum: 65_535 }
+  # ラケット投稿画像のバリデーション
+  validates :images,  content_type: { in: %w[image/jpeg image/gif image/png],
+                                      message: "画像フォーマットはjpeg,gif,pngのみ投稿できます。"},
+                      size:         { less_than: 5.megabytes,
+                                      message: "画像の大きさは5MB以下にしてください。"}
 end

--- a/app/views/rackets/edit.html.erb
+++ b/app/views/rackets/edit.html.erb
@@ -1,6 +1,12 @@
 <h1 class="text-2xl font-semibold ">編集画面</h1>
 <%= form_with model: @racket, class: "new_racket" do |f| %>
 
+    <!-- 使用ラケットの写真 -->
+  <div>
+    <%= f.label 'ラケット画像' %>
+    <%= f.file_field :images, multiple: true, accept: 'jpeg/png/gif' %>
+  </div>
+
   <!-- 使用ラケット名 -->
 	<div>
     <%= f.label '種類' %>

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -5,7 +5,7 @@
       <div>
         <% if racket.images.attached? %>
           <% racket.images.each do |image| %>
-            <%= image_tag image %>
+            <%= image_tag image.variant(resize_to_fit: [300, 200]) %>
           <% end %>
         <% end %>
       </div>

--- a/app/views/rackets/show.html.erb
+++ b/app/views/rackets/show.html.erb
@@ -1,5 +1,13 @@
 <h1 class="text-2xl font-semibold ">投稿詳細画面</h1>
   <div>
+    <% if @racket.images.attached? %>
+      <% @racket.images.each do |image| %>
+        <%= image_tag image.variant(resize_to_fit: [500, 400]) %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <div>
     <label>更新日:</label>
 	  <%= @racket.created_at %>
   </div>


### PR DESCRIPTION
# 概要
画像表示サイズの変更及び画像投稿にバリデーションを設定しました

## 画像サイズの変更
  app/views/rackets/index.html.erb
  app/views/rackets/show.html.erbを編集し表示サイズを変更

## バリデーションの実施
  app/models/racket.rbを編集

## 編集画面と詳細画面を編集機能で画像を投稿し、詳細画面で確認できるように変更
  app/views/rackets/edit.html.erb
  app/views/rackets/show.html.erbを編集