### PR TITLE
add:コメントチャット機能に削除機能を追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -28,9 +28,9 @@ class CommentsController < ApplicationController
     racket_id = @comment.racket_id
 
     if @comment.destroy
-     Rails.logger.info "Broadcasting destroy for comment #{@comment.id} on racket #{racket.id}"
+     Rails.logger.info "Broadcasting destroy for comment #{@comment.id} on racket #{racket_id}"
      CommentsChannel.broadcast_to(
-      "racket_#{racket.id}_comments",
+      "racket_#{racket_id}_comments",
       {
         action: 'destroy',
         comment_id: @comment.id

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -39,8 +39,8 @@ class CommentsController < ApplicationController
      head :ok
     else
     head :unprocessable_entity
+    end
   end
-
   private
 
   def comment_params

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -24,9 +24,21 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    comment = current_user.comments.find(params[:id])
-    comment.destroy!
-    redirect_to racket_path(comment.racket), success: "コメントを削除しました。"
+    @comment = current_user.comments.find(params[:id])
+    racket_id = @comment.racket_id
+
+    if @comment.destroy
+     Rails.logger.info "Broadcasting destroy for comment #{@comment.id} on racket #{racket.id}"
+     CommentsChannel.broadcast_to(
+      "racket_#{racket.id}_comments",
+      {
+        action: 'destroy',
+        comment_id: @comment.id
+      }
+     )
+     head :ok
+    else
+    head :unprocessable_entity
   end
 
   private

--- a/app/javascript/channels/comments_channel.js
+++ b/app/javascript/channels/comments_channel.js
@@ -1,6 +1,6 @@
 import consumer from "./consumer"
 
-document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function(){
   //constにて変数を定義
   const racketElement = document.querySelector('[data-racket-id]');
   const racketId = racketElement?.dataset.racketId;
@@ -69,6 +69,16 @@ if(racketId) {
       }
     }
 
+    //削除ボタンを押下時の動作を追加。
+    if(data.action === 'destroy'){
+      const commentElement = document.getElementById(`comment-${data.comment_id}`)
+      if(commentElement){
+        commentElement.remove();
+        console.log(`Coment ${data.comment_id} removed`)
+      }else{
+        console.error(`Comment ${data.comment_id} nota found`)
+      }
+    }
     //データの内容、(create,destroy)によって動作を変えるために一旦コメントアウト
     // if(commentsContainer && data.comment) {
     //   commentsContainer.insertAdjacentHTML('afterbegin', data.comment);
@@ -78,8 +88,42 @@ if(racketId) {
     // }
   }
   });
-}else{
-  console.log("No racket ID found, skipping WebSocket connection");
-  }
+}
+
+//コメントアウト（削除ボタンのイベント処理（イベント譲渡)を記載するため）
+// else{
+//   console.log("No racket ID found, skipping WebSocket connection");
+//   }
     //チャネルのWebSocketで受信データがあるときに呼び出される
+//削除ボタンのイベント処理（イベント譲渡)
+document.addEventListener('click', function(e){
+  if(e.target.classList.contains('delete-button')){
+    e.preventDefault();
+
+    const confirmMessage = e.target.database.confirm;
+    if(!confirm(confirmMessage)){
+      return;
+    }
+    const url = e.target.href;
+    //fetchでDELETEリクエスト
+    fetch(url,{
+      method: 'DELETE',
+      headers:{
+        'X-CSRF-Token': document.querySelector('[name="csrf-token"]').content,
+        'Accept': 'application/json'
+      }
+    })
+    .then(response =>{
+      if(!response.ok){
+        alert('削除に失敗しました!');
+      }
+    })
+    .catch(error => {
+    console.error('Error:',error);
+    alert('エラーが発生しました');
+    });
+
+
+  }
+});
 });

--- a/app/javascript/channels/comments_channel.js
+++ b/app/javascript/channels/comments_channel.js
@@ -74,7 +74,7 @@ if(racketId) {
       const commentElement = document.getElementById(`comment-${data.comment_id}`)
       if(commentElement){
         commentElement.remove();
-        console.log(`Coment ${data.comment_id} removed`)
+        console.log(`Comment ${data.comment_id} removed`)
       }else{
         console.error(`Comment ${data.comment_id} nota found`)
       }
@@ -100,7 +100,7 @@ document.addEventListener('click', function(e){
   if(e.target.classList.contains('delete-button')){
     e.preventDefault();
 
-    const confirmMessage = e.target.database.confirm;
+    const confirmMessage = e.target.dataset.confirm;
     if(!confirm(confirmMessage)){
       return;
     }

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -13,7 +13,13 @@
         <!-- 編集機能は本リリース時に実装" -->
 			  <div class="text-end">
 				  <!-- コメント削除ができないようにlink_toを変更 -->
-			    <%= link_to"削除", comment_path(comment), class: "text-white bg-red rounded-md pt-2 pb-1 pl-2 pr-1" ,data: { turbo: false, comment_id: comment.id, confirm: '削除しますか？' } %> <!-- `turbo_method: :delete, turbo_confirm: '削除しますか?`をturboを無効化する内容に変更" comment_idを定義 -->
+					<!-- js側で条件分岐できるように`delete-button`を追記 -->
+			    <%= link_to"削除", 
+					    comment_path(comment), 
+							class: "delete-button text-white bg-red rounded-md pt-2 pb-1 pl-2 pr-1" ,
+							data: { turbo: false, 
+							        comment_id: comment.id,
+											confirm: '削除しますか？' } %> <!-- `turbo_method: :delete, turbo_confirm: '削除しますか?`をturboを無効化する内容に変更" comment_idを定義 -->
 		    </div>
 	    <% end %>
 	  </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -12,8 +12,8 @@
       <% if current_user.own?(comment) %>
         <!-- 編集機能は本リリース時に実装" -->
 			  <div class="text-end">
-				  <!-- コメント削除ができないようにlink_toを変更 ->
-			    <% link_to"削除", comment_path(comment), class: "text-white bg-red rounded-md pt-2 pb-1 pl-2 pr-1" ,data: { turbo: false, comment_id: comment.id, confirm: '削除しますか？' } %> <!-- `turbo_method: :delete, turbo_confirm: '削除しますか?`をturboを無効化する内容に変更" comment_idを定義 -->
+				  <!-- コメント削除ができないようにlink_toを変更 -->
+			    <%= link_to"削除", comment_path(comment), class: "text-white bg-red rounded-md pt-2 pb-1 pl-2 pr-1" ,data: { turbo: false, comment_id: comment.id, confirm: '削除しますか？' } %> <!-- `turbo_method: :delete, turbo_confirm: '削除しますか?`をturboを無効化する内容に変更" comment_idを定義 -->
 		    </div>
 	    <% end %>
 	  </div>


### PR DESCRIPTION
# 概要
コメントチャット機能に削除機能を追加。
***
検証用アプリをもとに実装。
- コメントコントローラーにdestroyアクションを設定
- action_cableの機能変更
  - 削除ボタンを押した時の動作を追記
	- destroyアクションを受け取った時の動作を追記
- ラケット詳細画面にてコメント削除ボタンを復活
- エラー修正

## コメントコントローラーにdestroyアクションを設定
***
`/app/controllers/comments_controller.rb`を編集
以下のように変更
```
   def destroy
-    comment = current_user.comments.find(params[:id])
-    comment.destroy!
-    redirect_to racket_path(comment.racket), success: "コメントを削除しました。"
+    @comment = current_user.comments.find(params[:id])
+    racket_id = @comment.racket_id
+
+    if @comment.destroy
+     Rails.logger.info "Broadcasting destroy for comment #{@comment.id} on racket #{racket.id}"
+     CommentsChannel.broadcast_to(
+      "racket_#{racket.id}_comments",
+      {
+        action: 'destroy',
+        comment_id: @comment.id
+      }
+     )
+     head :ok
+    else
+    head :unprocessable_entity
   end
```
## action_cableの機能変更
***
`app/javascript/channels/comments_channel.js`を編集

## ラケット詳細画面にてコメント削除ボタンを復活
***
`app/views/comments/_comment.html.erb`を編集

## エラーを修正
***
- 削除ボタンを押すとリンクタブとして他の画面に遷移
  削除用`delete-button`を未設定だったので修正
- 削除ボタンを押しても反応がない
  コメントコントローラーのdestroyアクションの`end`を記載し忘れていたので修正
- 削除ボタンを押しても削除されない
  コメントコントローラーのdestroyアクション内で変数で定義している`racket_id`と記載するべきところを
	2箇所`racket.id`として記載していたので修正
