### PR TITLE
プロフィール詳細画面、ラケット詳細画面の画面が崩れるバグを修正

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,7 +1,7 @@
 <h1 class="text-7xl font-semibold text-center py-1 ">詳細画面</h1>
   <div  class="text-2xl text-navy flex justify-center" >
     <div>
-      <div class="my-5" >
+      <div class="my-5 flex justify-center" >
         <%= image_tag @profile.icon.variant(resize_to_fill: [ 300,300 ]), class: "rounded-full w-60, h-60" %>
 			</div>
 		  <div class="my-5" >
@@ -16,7 +16,7 @@
     <label>テニス歴:</label>
     <%= @profile.history %>
   </div>
-  <div class="my-5" >
+  <div class="my-5 break-all max-w-md" >
     <label>プレースタイル:</label>
     <%= @profile.play_style %>
   </div>
@@ -32,9 +32,10 @@
     <label>性別:</label>
     <%= @profile.gender_i18n %>
   </div>
-  <div class="my-5" >
-    <label>自己紹介:</label>
-    <%= @profile.body %>
+  <div class="my-5 break-all max-w-md" >
+      <label>自己紹介:</label>
+      <%= @profile.body %>
+    </p>
   </div>
 	<!-- プロフィールを投稿したユーザーがサインインしている場合に表示される -->
 	<%if user_signed_in? %>

--- a/app/views/rackets/show.html.erb
+++ b/app/views/rackets/show.html.erb
@@ -17,59 +17,59 @@
 	    <%= @racket.created_at %>
       </div>
 
-      <div class= "my-2">
+      <div class= "my-2 brek-all max-w-md">
         <label>種類:</label>
         <%= @racket.product_name %>
       </div>
 
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md">
         <label>メーカー:</label>
         <%= @racket.maker_name %>
       </div>
 
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md">
         <label>フェイスサイズ:</label>
         <%= @racket.face_size %>
       </div>
 
   <!-- 使用中のガット(縦)の種類 -->
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md">
         <label>使用ガット(縦):</label>
         <%= @racket.main_string %>
       </div>
 
   <!-- 使用中のガット(横)の種類 -->
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md">
         <label>使用ガット(横):</label>
         <%= @racket.cross_string %>
       </div>
 
  <!-- ガットのテンション(縦）-->
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md">
         <label>縦ガットのテンション:</label>
 	      <%= @racket.main_string_tension %>
       </div>
 
    <!-- ガットのテンション(横）-->
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md">
         <label>横ガットのテンション:</label>
         <%= @racket.cross_string_tension %>
       </div>
 
   <!-- 重りの使用箇所-->
-      <div class= "my-2">
+      <div class= "my-2  break-all max-w-md">
         <label>重りの使用箇所:</label>
         <%= @racket.weight_position %>
       </div>
 
   <!-- グリップの太さ -->
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md" >
         <label>グリップの太さ:</label>
         <%= @racket.grip_size %>
       </div>
 
   <!-- グリップテープ -->
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md">
         <label>グリップのテープ:</label>
         <%= @racket.grip_tape %>
       </div>
@@ -77,7 +77,7 @@
   <!-- タグ機能は本リリースにて実装 -->
 
 <!-- 自由記載エリア -->
-      <div class= "my-2">
+      <div class= "my-2 break-all max-w-md">
         <label>その他:</label>
         <%= @racket.body %>
       </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
       <% if user_signed_in? %>
         <%= link_to '投稿画面へ', new_racket_path %>
       <% if current_user.profile.present? %>
-          <%= link_to 'プロフィール編集画面へ', edit_profile_path(current_user.profile) %>
+          <%= link_to 'プロフィール詳細画面へ', profile_path(current_user.profile) %>
         <% else %>
           <%= link_to 'プロフィール投稿画面へ', new_profile_path %>
         <% end %>


### PR DESCRIPTION
プロフィール詳細画面、ラケット詳細画面の画面が崩れるバグを修正

# 概要
プロフィールの自己紹介欄、ラケット投稿のその他欄の文字数が多い時に改行されず画面が崩れるバグを修正

## プロフィール詳細画面の修正
原因はCSSで幅を設定していなかった事と改行するように設定していなかったこと。
`break-all max-w-md`に追加。
以下を修正
```
# app/views/profiles/show.html.erb

  <div class="my-5 break-all max-w-md" >
    <label>プレースタイル:</label>
    <%= @profile.play_style %>
  </div>
  
  <div class="my-5 break-all max-w-md" >
      <label>自己紹介:</label>
      <%= @profile.body %>
    </p>
  </div>
```
を追加。

## ラケット詳細画面も修正
プロフィール画面だけでなく、ラケット詳細画面でも同様に画面が崩れることを確認したため修正。
`break-all max-w-md`を追加。
`app/views/rackets/show.html.erb`を編集。
