### PR TITLE
タブのタイトルと画面のタイトルを動的に動かせるように変更

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def page_title(title = '')
+		base_title = 'My Rake'
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
+
+  def page_heading(title = '')
+    if title.present?
+      "#{title}"
+    end 
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/app/views/rackets/new.html.erb
+++ b/app/views/rackets/new.html.erb
@@ -1,4 +1,5 @@
-<h1 class="text-7xl font-semibold text-center mt-2 mb-1 pt-2 py-1">投稿画面</h1>
+<% content_for(:title, t('.title')) %>
+<h1 class="text-7xl font-semibold text-center mt-2 mb-1 pt-2 py-1"><%= t('.title') %></h1>
 
 <!-- フォーム画面を取得 -->
 <%= render 'form' %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,9 +1,10 @@
-<header class= 'py-8 bg-green text-yellow'>
-  <div class= 'container mx-auto flex justify-between items-center w-full'>
+<header class= 'h-20  bg-green text-yellow' >
+  <div class= 'container mx-auto flex justify-between items-center w-full h-full'>
     <div class='space-x-8'>
       <%= link_to 'TOP画面へ', root_path %>
       <%= link_to '投稿一覧画面へ', rackets_path %>
     </div>
+    <h1 class="text-4xl font-semibold text-center items-center" ><%= page_heading(yield(:title)) %></h1>
     <div class = 'space-x-12'>
       <% if user_signed_in? %>
         <%= link_to '投稿画面へ', new_racket_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,6 @@ module Myapp
     config.time_zone = 'Tokyo'
     # i18n 日本語対応
     config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,6 +10,12 @@ ja:
       created: ラケットの投稿に成功しました
       not_created:  ラケットの投稿に失敗しました
   rackets:
+    new:
+      title: 投稿画面
+    index:
+      title: みんらけ
+    show:
+      title: 詳細画面
     create:
       success: ラケットの投稿に成功しました
       failure: ラケットの投稿に失敗しました
@@ -18,4 +24,11 @@ ja:
       failure: ラケットの投稿に失敗しました
     destroy:
       success: 投稿したラケット情報を削除しました
+  profiles:
+    create:
+      success: プロフィールの作成に成功しました。
+      failure: プロフィールの作成に失敗しました。
+    update:
+      success: プロフィール情報の更新に成功しました。
+      failure: プロフィール情報の更新に失敗しました。
 


### PR DESCRIPTION
# 概要
タブのタイトルと画面のタイトルを動的に動かせるように以下のファイルを修正。
  `app/helpers/application_helper.rb`
  `app/views/layouts/application.html.erb`
  `app/views/rackets/new.html.erb`
  `app/views/shared/_header.html.erb`
  `config/application.rb`

併せて、日本語化対応(i18n)も修正
  `config/locales/views/ja.yml`

## タイトルの設定
  - `app/helpers/application_helper.rb`に`page_title`を設定
  ```
      def page_title(title = '')
		  base_title = 'My Rake'
         title.present? ? "#{title} | #{base_title}" : base_title
     end
   ```
  
  - `app/views/layouts/application.html.erb`を編集
  ```
  <head>
     <title><%= page_title(yield(:title)) %></title>
   </head>
  ```

	- `app/views/rackets/new.html.erb`を編集
  ```
	  <% content_for(:title, t('.title')) %>
  ```

## タイトル(heading)を動的に表示させる
  - `app/views/shared/_header.html.erb`を編集
  ` <h1 class="text-4xl font-semibold text-center items-center" ><%= page_heading(yield(:title)) %></h1>`を追記
 
## 日本語化対応(i18n)の修正
  - `config/application.rb`を編集
	`config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]` を追記

  - `config/locales/views/ja.yml`を編集
 　以下を追記
   ```
    ja:
      rackets:
        new:
          title: 投稿画面
        index:
          title: みんらけ
        show:
          title: 詳細画面
   ```