### PR TITLE
ラケットとプロフィールに関する画面のタイトルと画面のタイトルを動的に動かせるように変更

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,5 +1,4 @@
-<div class = "container mx-auto px-10 my-16 ">
-<!-- 以下のページタイトルはヘッダー部分に利用する必要がある -->
-<h1 class="text-5xl font-semibold text-center">プロフィール編集画面</h1>
- <%= render 'form' %>
-</div>
+<% content_for(:title, t('.title')) %>
+  <div class = "container mx-auto px-10 my-16 ">
+    <%= render 'form' %>
+  </div>

--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,5 +1,4 @@
+<% content_for(:title, t('.title')) %> <--! タイトル、ヘッダーでのheading表示を動的にするために追記 -->
 <div class = "container mx-auto px-10 my-16 ">
-<!-- 以下のページタイトルはヘッダー部分に利用する必要がある -->
-<h1 class="text-5xl font-semibold text-center">プロフィール投稿画面</h1>
- <%= render 'form' %>
+  <<%= render 'form' %>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-7xl font-semibold text-center py-1 ">詳細画面</h1>
+<% content_for(:title, t('.title')) %>
   <div  class="text-2xl text-navy flex justify-center" >
     <div>
       <div class="my-5 flex justify-center" >

--- a/app/views/rackets/edit.html.erb
+++ b/app/views/rackets/edit.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-2xl font-semibold ">編集画面</h1>
+<% content_for(:title, t('.title')) %>
 
 <!-- フォーム画面を取得 -->
 <%= render 'form' %>

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-4xl text-green-700 font-semibold text-center">投稿一覧画面</h1>
+<% content_for(:title, t('.title')) %>
   <div class="mx-24 grid grid-cols-3 gap-8">
     <% if @rackets.present? %>
       <% @rackets.each do |racket| %>

--- a/app/views/rackets/new.html.erb
+++ b/app/views/rackets/new.html.erb
@@ -1,5 +1,3 @@
 <% content_for(:title, t('.title')) %>
-<h1 class="text-7xl font-semibold text-center mt-2 mb-1 pt-2 py-1"><%= t('.title') %></h1>
-
 <!-- フォーム画面を取得 -->
 <%= render 'form' %>

--- a/app/views/rackets/show.html.erb
+++ b/app/views/rackets/show.html.erb
@@ -1,5 +1,4 @@
-
-<h1 class="text-7xl font-semibold text-center ">投稿詳細画面</h1>
+<% content_for(:title, t('.title')) %>
   <div class= "text-2xl flex justify-center">
     <div>
       <div class="mb-2">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,11 +1,11 @@
-<header class= 'h-20  bg-green text-yellow' >
+<header class= 'h-20  bg-green text-yellow relative' >
   <div class= 'container mx-auto flex justify-between items-center w-full h-full'>
-    <div class='space-x-8'>
+    <div class='space-x-4'>
       <%= link_to 'TOP画面へ', root_path %>
       <%= link_to '投稿一覧画面へ', rackets_path %>
     </div>
-    <h1 class="text-4xl font-semibold text-center items-center" ><%= page_heading(yield(:title)) %></h1>
-    <div class = 'space-x-12'>
+    <h1 class="absolute left-1/2 transform -translate-x-1/2 text-4xl font-semibold " ><%= page_heading(yield(:title)) %></h1>
+    <div class = 'space-x-8'>
       <% if user_signed_in? %>
         <%= link_to '投稿画面へ', new_racket_path %>
       <% if current_user.profile.present? %>
@@ -17,7 +17,7 @@
       <% else %>
         <%= link_to "新規登録", new_user_registration_path %>
         <%= link_to "ログイン", new_user_session_path %>
-	    <% end %>
+      <% end %>
     </div>
   </div>
 </header>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,6 +25,12 @@ ja:
     destroy:
       success: 投稿したラケット情報を削除しました
   profiles:
+    new:
+      title: プロフィール投稿
+    show:
+      title: プロフィール画面
+    edit:
+      title: プロフィール編集
     create:
       success: プロフィールの作成に成功しました。
       failure: プロフィールの作成に失敗しました。


### PR DESCRIPTION
# 概要
画面のタイトル(`h1`)の表示が画面センターに来ていなかったため、修正
未反映だった、ラケットとプロフィールに関する画面のタイトルと画面のタイトルを動的に動かせるように変更


## 画面のタイトル(`h1`)の位置を変更
  - `app/views/shared/_header.html.erb`を編集
	```
	  # 変更前
	  <header class= 'h-20  bg-green text-yellow ' >`

		 # 変更後
		<header class= 'h-20  bg-green text-yellow relative' >`
  ```
	```
	  # 変更前
    <h1 class="text-4xl font-semibold text-center items-center" ><%= page_heading(yield(:title)) %></h1>
    # 変更後
    <h1 class="absolute left-1/2 transform -translate-x-1/2 text-4xl font-semibold " ><%= page_heading(yield(:title)) %></h1>`
  ```

## ラケットに関する画面のタブのタイトルと画面タイトル(`h1`)を動的表示に変更
  以下ファイルに`content_for(:titile, t('.title'))`を記載し`h1`タグを削除
	```
	app/views/shared/_header.html.erb
  app/views/rackets/edit.html.erb
	app/views/rackets/index.html.erb
	app/views/rackets/new.html.erb
	app/views/rackets/show.html.erb
	```

## プロフィールに関する画面のタブのタイトルと画面タイトル(`h1`)を動的表示に変更
  - プロフィールに関する項目の日本語化対応
	  `config/locales/views/ja.yml`を編集
	
	- 各画面を動的表示に変更
  以下ファイルに`content_for(:titile, t('.title'))`を記載し`h1`タグを削除
  ```
	app/views/profiles/edit.html.erb
	app/views/profiles/new.html.erb
	app/views/profiles/show.html.erb
	```
