### PR TITLE
ラケット一覧画面の表示を変更。

### DIFF
--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -1,9 +1,8 @@
 <% content_for(:title, t('.title')) %>
-  <div class="mx-24 my-1 grid grid-cols-2 gap-8">
+  <div class="mx-24 my-1 x-10 grid grid-cols-2 gap-8">
     <% if @rackets.present? %>
       <% @rackets.each do |racket| %>
       <div class= "grid border border-colors-black" >
-        <div>
           <% if racket.images.attached? %>
             <% racket.images.each do |image| %>
               <%= image_tag image.variant(resize_to_fit: [300, 200]) %>
@@ -11,34 +10,43 @@
           <% else %>
             <%= image_tag 'temporary _sample.png', width: 300, height: "200" %>
           <% end %>
+          <div class='grid grid-cols-3 grid-rows-2'>
+              <% if racket.user.profile.present? %>
+                <div class="underline">
+                  <%= link_to racket.user.name, profile_path(racket.user.profile) %>
+                </div>
+              <% else %>
+                <div>
+                  <%= racket.user.name %>
+                </div>
+              <% end %>
+              <div class='underline'>
+                <%= link_to racket.product_name, racket_path(racket), data: { turbo: false } %> <!-- 名前を押すことで詳細画面へ遷移 詳細画面のコメントチャット機能にてturboを使用しないためturboをoff-->
+              </div>
+              <div>
+                 <% if user_signed_in? %>
+                  <% if current_user.own?(racket) %>
+                  <div>
+                    <%= link_to '編集', edit_racket_path(racket) %>
+                  </div>
+                  <% end %>
+                <% end %>
+              </div>
+              <div>
+                <%= racket.created_at.strftime('%y/%m/%d') %>
+              </div>
+              <div>
+                <%= racket.maker_name %>
+              </div>
+              <div>
+                <% if user_signed_in? %> <!-- レイアウトを整えるために、編集、削除でわけて記載 -->
+                  <% if current_user.own?(racket) %>
+                    <%= link_to '削除', racket_path(racket), data: { turbo_method: :delete, turbo_confirm: '削除しますか?'} %>
+                  <% end %>
+                <% end %>
+              </div>
+          </div>
         </div>
-        <div>
-          <% if racket.user.profile.present? %>
-            <div class = "underline">
-              <%= link_to racket.user.name, profile_path(racket.user.profile) %>
-            </div>
-          <% else %>
-            <%= racket.user.name %>
-          <% end %>
-        </div>
-        <div class = "underline">
-          <%= link_to racket.product_name, racket_path(racket), data: { turbo: false } %> <!-- 名前を押すことで詳細画面へ遷移 詳細画面のコメントチャット機能にてturboを使用しないためturboをoff-->
-        </div>
-        <div>
-          <%= racket.maker_name %>
-        </div>
-        <div>
-          <%= racket.created_at.strftime('%y/%m/%d') %>
-			  </div>
-        <div>
-          <% if user_signed_in? %> <!-- ユーザーがログインしているか確認 -->
-            <% if current_user.own?(racket) %> <!-- 投稿ユーザーがログインユーザー確認 -->
-              <%= link_to '編集', edit_racket_path(racket) %>
-              <%= link_to '削除', racket_path(racket), data: { turbo_method: :delete, turbo_confirm: '削除しますか?'} %>
-            <% end %>
-          <% end %>
-        </div>
-      </div>
       <% end %>
 	  <% else %>
       <p> 投稿がありません </p>

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -3,7 +3,7 @@
     <div class="max-w-sm  md:max-w-4xl mx-auto  my-1 grid grid-cols-1  md:grid-cols-2 gap-8 ">
       <% if @rackets.present? %>
         <% @rackets.each do |racket| %>
-        <div class= "grid border border-gray " >
+        <div class= "grid border border-gray" >
             <% if racket.images.attached? %>
               <% racket.images.each do |image| %>
                 <%= image_tag image.variant(resize_to_fit: [300, 200]), class:'mx-auto' %>
@@ -13,31 +13,31 @@
             <% end %>
             <div class='grid grid-cols-3 grid-rows-2'>
                 <% if racket.user.profile.present? %>
-                  <div class="underline">
+                  <div class="underline text-right truncate">
                     <%= link_to racket.user.name, profile_path(racket.user.profile) %>
                   </div>
                 <% else %>
-                  <div>
+                  <div class='text-center truncate'>
                     <%= racket.user.name %>
                   </div>
                 <% end %>
-                <div class='underline'>
+                <div class='px-1 underline text-center truncate'>
                   <%= link_to racket.product_name, racket_path(racket), data: { turbo: false } %> <!-- 名前を押すことで詳細画面へ遷移 詳細画面のコメントチャット機能にてturboを使用しないためturboをoff-->
                 </div>
-                <div>
+                <div class='py-1 pl-2 text-left'>
                   <% if user_signed_in? %>
                     <% if current_user.own?(racket) %>
                       <%= link_to '編集', edit_racket_path(racket) , class: " text-white bg-blue px-1 py-1 rounded-md items-right " %>
                     <% end %>
                   <% end %>
                 </div>
-                <div>
-                  <%= racket.created_at.strftime('%y/%m/%d') %>
+                <div class='text-right mr-1'>
+                  <%= racket.created_at.strftime('%y/%m/%d %H:%M') %>
                 </div>
-                <div>
+                <div class='px-1 text-center truncate'>
                   <%= racket.maker_name %>
                 </div>
-                <div>
+                <div class='py-1 pl-2 text-left '>
                   <% if user_signed_in? %> <!-- レイアウトを整えるために、編集、削除でわけて記載 -->
                     <% if current_user.own?(racket) %>
                       <%= link_to '削除', racket_path(racket), class: "text-white bg-red px-1 py-1 rounded-md " ,data: { turbo_method: :delete, turbo_confirm: '削除しますか?'} %>

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:title, t('.title')) %>
-  <div class="mx-24 grid grid-cols-3 gap-8">
+  <div class="mx-24 my-1 grid grid-cols-2 gap-8">
     <% if @rackets.present? %>
       <% @rackets.each do |racket| %>
-      <div class= "grid" >
+      <div class= "grid border border-colors-black" >
         <div>
           <% if racket.images.attached? %>
             <% racket.images.each do |image| %>
@@ -15,7 +15,7 @@
         <div>
           <% if racket.user.profile.present? %>
             <div class = "underline">
-              <%= link_to racket.user.name, profile_path(racket.user) %>
+              <%= link_to racket.user.name, profile_path(racket.user.profile) %>
             </div>
           <% else %>
             <%= racket.user.name %>

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -1,54 +1,53 @@
 <% content_for(:title, t('.title')) %>
-  <div class="mx-24 my-1 x-10 grid grid-cols-2 gap-8">
-    <% if @rackets.present? %>
-      <% @rackets.each do |racket| %>
-      <div class= "grid border border-colors-black" >
-          <% if racket.images.attached? %>
-            <% racket.images.each do |image| %>
-              <%= image_tag image.variant(resize_to_fit: [300, 200]) %>
-            <% end %>
-          <% else %>
-            <%= image_tag 'temporary _sample.png', width: 300, height: "200" %>
-          <% end %>
-          <div class='grid grid-cols-3 grid-rows-2'>
-              <% if racket.user.profile.present? %>
-                <div class="underline">
-                  <%= link_to racket.user.name, profile_path(racket.user.profile) %>
-                </div>
-              <% else %>
-                <div>
-                  <%= racket.user.name %>
-                </div>
+
+    <div class="max-w-sm  md:max-w-4xl mx-auto  my-1 grid grid-cols-1  md:grid-cols-2 gap-8 ">
+      <% if @rackets.present? %>
+        <% @rackets.each do |racket| %>
+        <div class= "grid border border-gray " >
+            <% if racket.images.attached? %>
+              <% racket.images.each do |image| %>
+                <%= image_tag image.variant(resize_to_fit: [300, 200]), class:'mx-auto' %>
               <% end %>
-              <div class='underline'>
-                <%= link_to racket.product_name, racket_path(racket), data: { turbo: false } %> <!-- 名前を押すことで詳細画面へ遷移 詳細画面のコメントチャット機能にてturboを使用しないためturboをoff-->
-              </div>
-              <div>
-                 <% if user_signed_in? %>
-                  <% if current_user.own?(racket) %>
-                  <div>
-                    <%= link_to '編集', edit_racket_path(racket) %>
+            <% else %>
+              <%= image_tag 'temporary _sample.png', width: 300, height: 200, class: 'mx-auto' %>
+            <% end %>
+            <div class='grid grid-cols-3 grid-rows-2'>
+                <% if racket.user.profile.present? %>
+                  <div class="underline">
+                    <%= link_to racket.user.name, profile_path(racket.user.profile) %>
                   </div>
-                  <% end %>
+                <% else %>
+                  <div>
+                    <%= racket.user.name %>
+                  </div>
                 <% end %>
-              </div>
-              <div>
-                <%= racket.created_at.strftime('%y/%m/%d') %>
-              </div>
-              <div>
-                <%= racket.maker_name %>
-              </div>
-              <div>
-                <% if user_signed_in? %> <!-- レイアウトを整えるために、編集、削除でわけて記載 -->
-                  <% if current_user.own?(racket) %>
-                    <%= link_to '削除', racket_path(racket), data: { turbo_method: :delete, turbo_confirm: '削除しますか?'} %>
+                <div class='underline'>
+                  <%= link_to racket.product_name, racket_path(racket), data: { turbo: false } %> <!-- 名前を押すことで詳細画面へ遷移 詳細画面のコメントチャット機能にてturboを使用しないためturboをoff-->
+                </div>
+                <div>
+                  <% if user_signed_in? %>
+                    <% if current_user.own?(racket) %>
+                      <%= link_to '編集', edit_racket_path(racket) , class: " text-white bg-blue px-1 py-1 rounded-md items-right " %>
+                    <% end %>
                   <% end %>
-                <% end %>
-              </div>
+                </div>
+                <div>
+                  <%= racket.created_at.strftime('%y/%m/%d') %>
+                </div>
+                <div>
+                  <%= racket.maker_name %>
+                </div>
+                <div>
+                  <% if user_signed_in? %> <!-- レイアウトを整えるために、編集、削除でわけて記載 -->
+                    <% if current_user.own?(racket) %>
+                      <%= link_to '削除', racket_path(racket), class: "text-white bg-red px-1 py-1 rounded-md " ,data: { turbo_method: :delete, turbo_confirm: '削除しますか?'} %>
+                    <% end %>
+                  <% end %>
+                </div>
+            </div>
           </div>
-        </div>
+        <% end %>
+      <% else %>
+        <p> 投稿がありません </p>
       <% end %>
-	  <% else %>
-      <p> 投稿がありません </p>
-    <% end %>
-  </div>
+    </div>

--- a/app/views/rackets/index.html.erb
+++ b/app/views/rackets/index.html.erb
@@ -28,7 +28,7 @@
           <%= racket.maker_name %>
         </div>
         <div>
-          <%= racket.created_at %>
+          <%= racket.created_at.strftime('%y/%m/%d') %>
 			  </div>
         <div>
           <% if user_signed_in? %> <!-- ユーザーがログインしているか確認 -->

--- a/app/views/rackets/show.html.erb
+++ b/app/views/rackets/show.html.erb
@@ -13,7 +13,7 @@
 
       <div class= "my-2">
       <label>更新日:</label>
-	    <%= @racket.created_at %>
+	    <%= @racket.created_at.strftime('%y-%m-%m %H:%M') %>
       </div>
 
       <div class= "my-2 brek-all max-w-md">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -16,6 +16,8 @@ ja:
       title: みんらけ
     show:
       title: 詳細画面
+    edit:
+     title: 編集画面
     create:
       success: ラケットの投稿に成功しました
       failure: ラケットの投稿に失敗しました


### PR DESCRIPTION
# 概要
ラケット一覧画面の表示を変更。
racket編集画面でのタイトルの日本語化対応
`app/views/rackets/index.html.erb`
`config/locales/views/ja.yml`
***
## 投稿日、更新日の日付の表示を変更
`<%= racket.created_at.strftime('%y/%m/%d %H:%M') %>`に変更

***
## 投稿ユーザーの名前を表示できるように変更。名前を押すとプロフィールユーザーページへ遷移するように変更
`<%= link_to racket.user.name, profile_path(racket.user.profile) %>`に変更

***
## racket編集画面でのタイトルの日本語化対応
`config/locales/views/ja.yml`に追記
```
rackets:
  edit:
   title: 編集画面
```

***
## 投稿一覧画面のgrid内を2行x3列に変更
`<div class='grid grid-cols-3 grid-rows-2'></div>`を追記。
子要素の`<div>`を見直す。

***
## 投稿内容の配置をレスポンシブに対応。画像をセンターに変更
基本の投稿一覧ページを1つに変更し、画面がタブレット以上の`md`の場合に2つにするように変更。

***
## ラケットの一覧画面をgrid内のレイアウトを変更
grid内の各要素に配置を記載する。

***