### PR TITLE
fix:コード内のコメントが表示されていため修正

### DIFF
--- a/app/views/profiles/new.html.erb
+++ b/app/views/profiles/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %> <--! タイトル、ヘッダーでのheading表示を動的にするために追記 -->
+<% content_for(:title, t('.title')) %> <!-- タイトル、ヘッダーでのheading表示を動的にするために追記 -->
 <div class = "container mx-auto px-10 my-16 ">
   <<%= render 'form' %>
 </div>


### PR DESCRIPTION
# 概要
プロフィール投稿画面にてコード内のコメントが表示されていたので修正
```
# app/views/profiles/new.html.erb
# 変更前
`<% content_for(:title, t('.title')) %> <--! タイトル、ヘッダーでのheading表示を動的にするために追記 -->`

# 変更後
`<% content_for(:title, t('.title')) %> <!-- タイトル、ヘッダーでのheading表示を動的にするために追記 -->`
```