### PR TITLE
deviseの日本語化対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,3 +85,6 @@ gem 'enum_help'
 
 # solid_cableの導入
 gem "solid_cable", "~> 3.0"
+
+#deviseの日本語化対応
+gem "devise-i18n"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.15.0)
+      devise (>= 4.9.0)
+      rails-i18n
     drb (2.2.1)
     enum_help (0.0.19)
       activesupport (>= 3.0.0)
@@ -394,6 +397,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  devise-i18n
   enum_help
   image_processing (>= 1.2)
   jbuilder

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,7 +17,7 @@
   <div class="field text-2xl">
     <%= f.label :password %>
     <% if @minimum_password_length %>
-    <em>(<%= @minimum_password_length %> characters minimum)</em>
+    <em>(<%= t(".minimum_password_length", count: @minimum_password_length) %>)</em>
     <% end %><br />
     <%= f.password_field :password, autocomplete: "new-password", class: "w-full border border-x-black border-y-black" %>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -43,7 +43,7 @@
   </div>
 	<!-- プロフィールを投稿したユーザーがサインインしている場合に表示される -->
 	<%if user_signed_in? %>
-    <div class= 'mt-2 text-center'>
+    <div class= 'my-2 text-center'>
       <!--  投稿編集、削除機能 -->
       <% if current_user.own?(@profile) %>
         <%= link_to '編集', edit_profile_path(@profile), class: "text-2xl text-white bg-green px-5 py-2 rounded-md " %>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -2,3 +2,10 @@ ja:
   activerecord:
     models:
       user: ユーザー
+    attributes:
+      user:
+        name: プレイヤーネーム
+        email: メールアドレス
+        password: パスワード
+      new:
+        characters minimum: 文字以上

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,10 @@
+ja:
+  devise:
+    sessions:
+      name: 名前
+      email: メールアドレス
+      password: パスワード
+      remember_me: ログインを維持する
+    registrations:
+      new:
+        minimum_password_length: "%{count}文字以上"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -39,10 +39,4 @@ ja:
     update:
       success: プロフィール情報の更新に成功しました。
       failure: プロフィール情報の更新に失敗しました。
-  devise:
-    sessions:
-      name: 名前
-      email:  メールアドレス
-      password:  パスワード
-      remember_me:  ログインを維持する
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -39,4 +39,10 @@ ja:
     update:
       success: プロフィール情報の更新に成功しました。
       failure: プロフィール情報の更新に失敗しました。
+  devise:
+    sessions:
+      name: 名前
+      email:  メールアドレス
+      password:  パスワード
+      remember_me:  ログインを維持する
 

--- a/config/views/ja.yml
+++ b/config/views/ja.yml
@@ -21,3 +21,7 @@ ja:
     update:
       success: プロフィール情報の更新に成功しました
       failure: プロフィール情報の更新に失敗しました
+  devise:
+    registrations:
+      new:
+        characters: 文字


### PR DESCRIPTION
# 概要
***
## devise-18nのインストール
Gemfileに以下を追記
```
#deviseの日本語化対応
gem "devise-i18n"
```
`docker compose exec web bundle install`を実行
***
## 新規登録画面のパスワードの日本語化
文字列のため、`deivse-i18n`を入れても日本語化されないため個別で対応
 
`app/views/devise/registapp/views/devise/registrations/new.html`を編集
```
<div class="field text-2xl">
    <%= f.label :password %>
    <% if @minimum_password_length %>
    <em>(<%= t(".minimum_password_length", count: @minimum_password_length) %>)</em>
    <% end %><br />
    <%= f.password_field :password, autocomplete: "new-password", class: "w-full border border-x-black border-y-black" %>
  </div>
``` 
`config/locales/devise.ja.yml`を編集
```
ja:
  devise:
    registrations:
      new:
        minimum_password_length: "%{count}文字以上"
```
 

